### PR TITLE
BOOT-18 Audio playing twice when video is played into master

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -136,6 +136,7 @@ export default {
   },
   mounted() {
     // window.addEventListener('scroll', this.handleScroll)
+    this.isMobile = window.innerWidth < 560
     window.addEventListener(
       'resize',
       () => (this.isMobile = window.innerWidth < 560)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,7 +11,6 @@
           <h3>Watch</h3>
         </button>
       </div>
-      <div v-html="video" class="player" />
       <h1>
         <button @click="playVideo">
           The ultimate platform for fans<br />to scout and transfer players
@@ -22,11 +21,11 @@
       </h1>
     </div>
     <div :class="isPlaying ? 'is-playing' : null" class="video-modal">
-      <div v-html="video" class="player" />
+      <div class="player" v-html="video" />
       <button
-        @click="closeVideo"
         class="modal-close is-large"
         aria-label="close"
+        @click="closeVideo"
       ></button>
     </div>
     <!-- <div class="container is-12 aspect-ratio-box">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -312,7 +312,7 @@ export default {
     min-height: 75vh;
 
     .player {
-      margin-top: 125px;
+      margin-top: 105px;
     }
 
     h1 {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,7 +11,15 @@
           <h3>Watch</h3>
         </button>
       </div>
-      <div v-if="isMobile" class="player" v-html="video" />
+      <div v-if="isPlaying" class="player">
+        <iframe
+          src="https://player.vimeo.com/video/576805134?color=ff0086&title=0&byline=0&portrait=0&autoplay=true"
+          class="video-iframe"
+          frameborder="0"
+          allow="autoplay; fullscreen"
+          allowfullscreen
+        ></iframe>
+      </div>
       <h1>
         <button @click="playVideo">
           The ultimate platform for fans<br />to scout and transfer players
@@ -20,14 +28,6 @@
           > -->
         </button>
       </h1>
-    </div>
-    <div :class="isPlaying ? 'is-playing' : null" class="video-modal">
-      <div v-if="!isMobile" class="player" v-html="video" />
-      <button
-        class="modal-close is-large"
-        aria-label="close"
-        @click="closeVideo"
-      ></button>
     </div>
     <!-- <div class="container is-12 aspect-ratio-box">
         <client-only>
@@ -122,7 +122,6 @@ export default {
       email: '',
       video: '',
       isPlaying: false,
-      isMobile: undefined,
       opacity: 1,
       error: ''
     }
@@ -136,60 +135,38 @@ export default {
   },
   mounted() {
     // window.addEventListener('scroll', this.handleScroll)
-    this.isMobile = window.innerWidth < 560
-    window.addEventListener(
-      'resize',
-      () => (this.isMobile = window.innerWidth < 560)
-    )
   },
   methods: {
-    closeVideo() {
-      this.isPlaying = false
-      this.video = ''
-    },
     handleScroll() {
       const st = window.scrollY
       this.opacity = 1 - (1 / window.innerHeight) * st
     },
     playVideo() {
       this.isPlaying = true
-      this.video = `<div style="padding:56.25% 0 0 0;position:relative;">
-                        <iframe src="https://player.vimeo.com/video/576805134?color=ff0086&title=0&byline=0&portrait=0&autoplay=true" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
-                        </div>`
     }
   }
 }
 </script>
 
 <style lang="scss">
-// iframe {
-//   width: 100%;
-//   height: 45vh;
-//   position: absolute;
-//   top: 0;
-//   left: 0;
-// }
+.video-iframe {
+  width: 100%;
+  height: 100%;
+}
 
 .error {
   color: red;
 }
 
 .video {
+  display: flex;
+  justify-content: center;
   position: relative;
   overflow: hidden;
   top: 0;
   left: 0;
   width: 100%;
-  // position: relative;
   min-height: 55vh;
-
-  .player {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    width: 100%;
-    transform: translateY(-35%);
-  }
 
   h1 {
     position: absolute;
@@ -213,6 +190,11 @@ export default {
     span {
       color: #267efc;
     }
+  }
+
+  .player {
+    width: 100%;
+    margin-top: 65px;
   }
 
   .poster {
@@ -267,10 +249,6 @@ export default {
   }
 }
 
-.video-modal {
-  display: none;
-}
-
 .wrap {
   position: relative;
   z-index: 5;
@@ -317,10 +295,6 @@ export default {
 }
 
 @media only screen and (min-width: 560px) {
-  iframe {
-    height: 90%;
-  }
-
   .wrap {
     position: relative;
     z-index: 5;
@@ -338,12 +312,7 @@ export default {
     min-height: 75vh;
 
     .player {
-      position: fixed;
-      top: 50%;
-      left: 0;
-      width: 100%;
-      transform: translateY(-40%);
-      display: none;
+      margin-top: 125px;
     }
 
     h1 {
@@ -401,33 +370,6 @@ export default {
       padding: 0;
       background-color: transparent;
       cursor: pointer;
-    }
-  }
-
-  .video-modal {
-    position: fixed;
-    display: block;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-    background-color: rgba(0, 0, 0, 1);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.3s;
-
-    &.is-playing {
-      opacity: 1;
-      pointer-events: all;
-    }
-
-    .player {
-      position: absolute;
-      top: 50%;
-      left: 10%;
-      width: 80%;
-      transform: translateY(-50%);
     }
   }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,6 +11,7 @@
           <h3>Watch</h3>
         </button>
       </div>
+      <div v-if="isMobile" class="player" v-html="video" />
       <h1>
         <button @click="playVideo">
           The ultimate platform for fans<br />to scout and transfer players
@@ -21,7 +22,7 @@
       </h1>
     </div>
     <div :class="isPlaying ? 'is-playing' : null" class="video-modal">
-      <div class="player" v-html="video" />
+      <div v-if="!isMobile" class="player" v-html="video" />
       <button
         class="modal-close is-large"
         aria-label="close"
@@ -121,6 +122,7 @@ export default {
       email: '',
       video: '',
       isPlaying: false,
+      isMobile: undefined,
       opacity: 1,
       error: ''
     }
@@ -134,6 +136,10 @@ export default {
   },
   mounted() {
     // window.addEventListener('scroll', this.handleScroll)
+    window.addEventListener(
+      'resize',
+      () => (this.isMobile = window.innerWidth < 560)
+    )
   },
   methods: {
     closeVideo() {


### PR DESCRIPTION
- Fix [BOOT-18](https://bootbag.atlassian.net/browse/BOOT-18) by removing the video modal. Use display flex and justify content to position the player instead of position absolute (this no longer works after removing the video modal on desktop).

I've also tested to make sure the video still plays as expected on mobile, tablet and desktop. Along with Chrome, Safari and Firefox.

https://user-images.githubusercontent.com/60143986/224273963-d185238f-1a2e-41f6-bcc4-92bb9f032243.mov


