### PR TITLE
Add cross env to build staging to support windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "css-watch": "npm run css-build -- --watch",
     "dev": "cross-env NODE_ENV=development nodemon server/index.js --watch server",
     "build": "nuxt generate",
-    "build:staging": "FIRE_ENV=bootbag-staging nuxt generate",
+    "build:staging": "cross-env FIRE_ENV=bootbag-staging nuxt generate",
     "start": "nuxt start",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "test": "jest",


### PR DESCRIPTION
- Add cross env to `npm run build:staging` command to support windows. Tested this command again to make sure the env variables update correctly.