### PR TITLE
BOOT-19 Copy changes and yellow banner alignment

### DIFF
--- a/components/SignUp.vue
+++ b/components/SignUp.vue
@@ -1,8 +1,7 @@
 <template>
   <section :class="cls" class="yellowSection  has-text-centered">
     <p>
-      <span>Join The Revolution</span
-      ><strong>Register To Become A Scout</strong>
+      <span>Live</span><strong>Register for the Head Scout position</strong>
       <button
         class="button is-primary"
         data-target="modal"
@@ -15,14 +14,14 @@
     <div id="modal" :class="[showPopup ? 'modal is-active' : '', 'modal']">
       <div class="modal-background"></div>
       <div class="modal-content">
-        <p class="title">Join The Revolution.</p>
-        <p class="subTitle">Register To Become A Scout.</p>
+        <p class="title">LIVE</p>
+        <p class="subTitle">Register for the Head Scout position.</p>
         <img src="../assets/images/popup-circle-left.png" class="popupLeft" />
         <img src="../assets/images/popup-circle-right.png" class="popupRight" />
         <div v-if="!sending && success">
           <p class="successMessage">
-            You have Successfully Registered for Bootbag, keep an eye on your
-            emails for more details!
+            Congratulations, you have been hired as the Head Scout. Keep an eye
+            on your emails for more details!
           </p>
         </div>
         <form v-else @submit.prevent="sendEmail">
@@ -132,7 +131,9 @@ export default {
   }
 
   p {
-    display: inline-block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     span,
     strong,
@@ -185,7 +186,7 @@ export default {
     .title {
       font-size: 20px;
       text-transform: uppercase;
-      margin: 0;
+      margin: 0 auto;
       padding: 0 20px;
       width: 80%;
       text-align: center;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -39,19 +39,20 @@
               <span>Breaking News!</span> <span>You Are Now Registered.</span>
             </h2>
             <h2 v-else>
-              <span>Live</span> <span>Register To Become A Scout.</span>
+              <span>Live</span>
+              <span>Register for the Head Scout position.</span>
             </h2>
           </div>
           <div class="coming-soon desktop">
             <h2>
-              Register To Become A Scout.
+              Register for the Head Scout position.
             </h2>
           </div>
           <div class="coming-soon">
             <div v-if="!sending && success">
               <p>
-                You have Successfully Registered for Bootbag, keep an eye on
-                your emails for more details!
+                Congratulations, you have been hired as the Head Scout. Keep an
+                eye on your emails for more details!
               </p>
             </div>
             <form v-else @submit.prevent="sendEmail">
@@ -111,8 +112,8 @@
             <div class="column ticket">
               <img src="~/assets/images/Pick-Roster-icon@2x.png" />
               <p class="text">
-                Choose from over
-                <strong>7500<br />players from<br />across the world.</strong>
+                Scout players from <br />England's divisions,<br />
+                <strong>Top 4 and the WSL!</strong>
               </p>
               <img
                 src="../assets/images/ticket-left-new.png"


### PR DESCRIPTION
Copy changes 

1. Changed registration confirmation copy to ("Congratulations, you have been hired as the Head Scout. Keep an eye on your email for more details!")
2. Changed yellow banner and modal copy to "LIVE | Register for the Head Scout position."
3. Changed card copy to "SCOUT PLAYERS FROM ENGLAND'S DIVISIONS,TOP 4 AND THE WSL!"

![image](https://user-images.githubusercontent.com/129167065/229745379-69c18984-c978-4647-a0f5-7b0406a7c672.png)
![image](https://user-images.githubusercontent.com/129167065/229745610-6bc98fd5-25dd-45d9-8711-2de71a618ae8.png)

![image](https://user-images.githubusercontent.com/129167065/229745244-c954f8f4-033f-40f0-824e-a0caa9f67a4c.png)
![image](https://user-images.githubusercontent.com/129167065/229746124-5ff65589-a258-4245-bf83-5540c959ef3c.png)

![image](https://user-images.githubusercontent.com/129167065/229747365-b1d42f84-3967-49ed-96ca-30d15b8c6586.png)
![image](https://user-images.githubusercontent.com/129167065/229747697-6010d586-ea71-463b-9210-103b4d6d88e3.png)
