### PR TITLE
BOOT-142 Restore default bulma button padding, add bulma input class

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -328,7 +328,6 @@ form {
   button[type='submit'] {
     font-size: 18px;
     line-height: 18px;
-    padding: 10px 0;
     color: #ffffff;
     display: inline-block;
     margin-bottom: 0;
@@ -461,7 +460,12 @@ form {
 
 @media only screen and (min-width: 768px) {
   form {
+    min-width: 500px;
     width: 50%;
+
+    .column {
+      padding: 0.5rem;
+    }
   }
 
   input[type='email'] {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -61,7 +61,7 @@
                   <input
                     v-model="email"
                     type="email"
-                    class="column"
+                    class="column input"
                     placeholder="Email Address"
                   />
                   <span v-if="error" class="error">
@@ -72,7 +72,7 @@
                   <button
                     :disabled="sending"
                     type="submit"
-                    class="column button is-primary"
+                    class="button is-primary"
                   >
                     <img v-if="sending" src="~/assets/spinner.svg" />
                     <span v-else>Register Now</span>


### PR DESCRIPTION
https://bootbag.atlassian.net/browse/BOOT-142

Restored the default bulma padding on their `.button` class and added bulma's `.input` class to our email input field which adds rounded corners.

Had to add min-width to the form to ensure elements stayed centered since the new padding isn't responsive to changes in parent container size and also reduced the gap between input and button.


https://user-images.githubusercontent.com/129167065/229843301-04940d63-5956-4f0a-9349-ced20662eeb3.mov

