### PR TITLE
BOOT-233 Swap out Vimeo Video

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,7 @@
       </div>
       <div v-if="isPlaying" class="player">
         <iframe
-          src="https://player.vimeo.com/video/576805134?color=ff0086&title=0&byline=0&portrait=0&autoplay=true"
+          src="https://player.vimeo.com/video/821291657?color=ff0086&title=0&byline=0&portrait=0&autoplay=true"
           class="video-iframe"
           frameborder="0"
           allow="autoplay; fullscreen"


### PR DESCRIPTION
- Changed video which is shown on the home page
It is hard to show that the video has changed because they look very similar but it has changed
<img width="939" alt="image" src="https://github.com/Sapien-Interactive/bootbag-static/assets/126271842/3f61c147-4b2e-4439-8d82-f31bd7ec3043">


I spoke to Russ about the controls being different and that's something for him to look into on his end 
https://bootbag.atlassian.net/browse/BOOT-233?focusedCommentId=10591
https://mmtdigital.slack.com/archives/C04Q7AV4DJQ/p1683725412137509